### PR TITLE
Switch frontend to Vue 3 built with Vite

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "build": {
-    "beforeBuildCommand": "",
-    "beforeDevCommand": "",
-    "devPath": "../ui/Zela",
+    "beforeBuildCommand": "npm run build",
+    "beforeDevCommand": "npm run dev",
+    "devPath": "http://localhost:5173",
     "distDir": "../ui/Zela",
     "withGlobalTauri": true
   },

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Zela</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/main.js"></script>
+</body>
+</html>

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "dev": "vite",
+    "build": "vite build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -18,10 +20,13 @@
     "@interactjs/modifiers": "^1.10.26",
     "@tauri-apps/cli": "^1.5.9",
     "dragula": "^3.7.3",
-    "interactjs": "^1.10.26"
+    "interactjs": "^1.10.26",
+    "vue": "^3.4.21"
   },
   "devDependencies": {
     "@interactjs/interact": "^1.10.26",
-    "@tauri-apps/api": "^1.5.3"
+    "@tauri-apps/api": "^1.5.3",
+    "@vitejs/plugin-vue": "^5.0.3",
+    "vite": "^5.2.0"
   }
 }

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="container">
+    <h1>Zela Vue 3</h1>
+    <button @click="callTest">Invoke Backend</button>
+  </div>
+</template>
+
+<script setup>
+import { invoke } from '@tauri-apps/api/tauri'
+
+const callTest = () => {
+  invoke('test').then(resp => {
+    console.log(resp)
+  })
+}
+</script>
+
+<style>
+.container {
+  padding: 1rem;
+}
+</style>

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  build: {
+    outDir: 'Zela'
+  }
+})


### PR DESCRIPTION
## Summary
- add a minimal Vue 3 project using Vite
- configure build output for Tauri
- update package.json with Vue & Vite
- update Tauri config to run Vite dev/build commands

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841296ce4d8832485201c5fae18c75f